### PR TITLE
API endpoint to authenticate users

### DIFF
--- a/src/app/handler/errors.go
+++ b/src/app/handler/errors.go
@@ -47,6 +47,10 @@ func UnprocessableEntity(validationErrors map[string][]string) HandlerError {
 	return apiError
 }
 
+func NotFound() HandlerError {
+	return newHandlerError(http.StatusNotFound, errors.New("Not found"))
+}
+
 func InternalServerError() HandlerError {
 	return newHandlerError(http.StatusInternalServerError, errors.New("Something went wrong"))
 }

--- a/src/auth/auth.go
+++ b/src/auth/auth.go
@@ -1,0 +1,11 @@
+package auth
+
+func GenerateToken(id string) (*Token, error) {
+	tokenService := NewTokenService()
+	tokenService.SetClaims(&AuthClaims{UserId: id})
+	tokenString, err := tokenService.CreateToken()
+	if err != nil {
+		return nil, err
+	}
+	return &Token{Value: tokenString}, nil
+}

--- a/src/auth/jwt.go
+++ b/src/auth/jwt.go
@@ -6,6 +6,7 @@ import (
 )
 
 // TODO add this to a secrets file. Get it from env in production
+// or pass it to NewTokenService one level up
 var authSecret = "my-secret-key"
 
 type JwtError struct {
@@ -17,28 +18,43 @@ func (e JwtError) Error() string {
 }
 
 type TokenService struct {
+	claims AuthClaims
 }
 
 func NewTokenService() *TokenService {
 	return &TokenService{}
 }
 
+func (t *TokenService) GetClaims() AuthClaims {
+	return t.claims
+}
+
+func (t *TokenService) SetClaims(claims *AuthClaims) {
+	t.claims = *claims
+}
+
 func (t *TokenService) CreateToken() (string, error) {
-	claims := jwt.MapClaims{}
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, t.claims)
 	return token.SignedString([]byte(authSecret))
 }
 
-func (t *TokenService) ValidateToken(tokenString string) error {
-	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
-		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
-			return nil, errors.New("Invalid JWT signing method")
-		}
-		return []byte(authSecret), nil
-	})
+func (t *TokenService) ParseToken(tokenString string) error {
+	token, err := jwt.ParseWithClaims(tokenString, &AuthClaims{}, parser)
+	if err != nil {
+		return err
+	}
 
-	if err != nil || !token.Valid {
+	if claims, ok := token.Claims.(*AuthClaims); ok && token.Valid {
+		t.SetClaims(claims)
+	} else {
 		return &JwtError{Err: errors.New("Invalid JWT token")}
 	}
 	return nil
+}
+
+func parser(token *jwt.Token) (interface{}, error) {
+	if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+		return nil, errors.New("Invalid JWT signing method")
+	}
+	return []byte(authSecret), nil
 }

--- a/src/auth/models.go
+++ b/src/auth/models.go
@@ -1,0 +1,14 @@
+package auth
+
+import (
+	jwt "github.com/dgrijalva/jwt-go"
+)
+
+type Token struct {
+	Value string `json:"token,omitempty"`
+}
+
+type AuthClaims struct {
+	UserId string `json:"user_id"`
+	jwt.StandardClaims
+}

--- a/src/users/configure.go
+++ b/src/users/configure.go
@@ -8,4 +8,5 @@ import (
 func Configure(env *app.Env) {
 	router := env.GetRouter()
 	router.Handle("/users", handler.AppHandler(env, Create)).Methods("POST")
+	router.Handle("/authenticate", handler.AppHandler(env, Authenticate)).Methods("POST")
 }

--- a/src/users/errors.go
+++ b/src/users/errors.go
@@ -1,0 +1,15 @@
+package users
+
+type AuthInvalidEmailError struct {
+}
+
+func (e *AuthInvalidEmailError) Error() string {
+	return "Email does not exist"
+}
+
+type AuthInvalidPasswordError struct {
+}
+
+func (e *AuthInvalidPasswordError) Error() string {
+	return "Password is invalid"
+}

--- a/src/users/models.go
+++ b/src/users/models.go
@@ -12,14 +12,6 @@ type User struct {
 	EncryptedPassword string `json:"-"`
 }
 
-func (user *User) encryptPassword(password string) error {
-	encrypted_password, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
-	if err == nil {
-		user.EncryptedPassword = string(encrypted_password)
-	}
-	return err
-}
-
 func NewUser(params UserParams) (User, error) {
 	user := User{Email: params.Email}
 	err := user.encryptPassword(params.Password)
@@ -28,6 +20,14 @@ func NewUser(params UserParams) (User, error) {
 	}
 
 	return user, nil
+}
+
+func (user *User) encryptPassword(password string) error {
+	encryptedPassword, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err == nil {
+		user.EncryptedPassword = string(encryptedPassword)
+	}
+	return err
 }
 
 type UserParams struct {

--- a/src/users/services.go
+++ b/src/users/services.go
@@ -1,0 +1,51 @@
+package users
+
+import (
+	"app"
+	"auth"
+	"golang.org/x/crypto/bcrypt"
+	"strconv"
+)
+
+type AuthService struct {
+	env *app.Env
+}
+
+func NewAuthService(env *app.Env) *AuthService {
+	return &AuthService{env: env}
+}
+
+func (service *AuthService) Authenticate(params UserParams) (*auth.Token, error) {
+	var token *auth.Token
+
+	user, err := service.findUser(params.Email)
+	if err != nil {
+		return token, err
+	}
+
+	if err = checkPassword(user.EncryptedPassword, params.Password); err != nil {
+		return token, &AuthInvalidPasswordError{}
+	}
+
+	token, err = auth.GenerateToken(strconv.FormatInt(user.Id, 10))
+	if err != nil {
+		return token, err
+	}
+	return token, nil
+}
+
+func (service *AuthService) findUser(email string) (*User, error) {
+	repository := NewRepository(service.env.GetDB())
+	user, err := repository.FindUserByEmail(email)
+	if err != nil {
+		return nil, err
+	}
+	if user == nil {
+		return user, &AuthInvalidEmailError{}
+	}
+	return user, nil
+}
+
+func checkPassword(encryptedPassword string, password string) error {
+	return bcrypt.CompareHashAndPassword([]byte(encryptedPassword), []byte(password))
+}


### PR DESCRIPTION
Implements: #28

__CHANGELOG__:
- Added handler.NotFound error.
- Added auth package
- Created endpoint to authenticate a user. Routes to POST /authenticate. Accepts email and password. Responds with 200 OK and a JWT token on successful authentication. Responds with 404 Not found if
email is invalid or 422 Unprocessable entity if password is invalid.